### PR TITLE
Fix the release version to be lower that 1.0.0 before the official release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,11 +64,6 @@ jobs:
         if: "! steps.check-version.outputs.tag"
         run: |
           echo "token=$(aws secretsmanager get-secret-value --secret-id ${{ vars.TEST_PYPI_TOKEN_NAME }} | jq -r '.SecretString')" >> $GITHUB_OUTPUT
-      - name: Retrieve PYPI TOKEN from secretsmanager
-        id: get-pypi-token
-        if: steps.check-version.outputs.tag
-        run: |
-          echo "token=$(aws secretsmanager get-secret-value --secret-id ${{ vars.PYPI_TOKEN_NAME }} | jq -r '.SecretString')" >> $GITHUB_OUTPUT
       - name: Publish package on TestPyPI
         if: "! steps.check-version.outputs.tag"
         uses: pypa/gh-action-pypi-publish@release/v1
@@ -76,9 +71,3 @@ jobs:
           user: __token__
           password: ${{ steps.get-test-pypi-token.outputs.token }}
           repository_url: https://test.pypi.org/legacy/
-      - name: Publish package on PyPI
-        if: steps.check-version.outputs.tag
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ steps.get-pypi-token.outputs.token }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amazon-sqs-extended-client"
-version = "1.0.0"
+version = "0.1.0"
 description = "Python version of AWS SQS extended client"
 authors = ["Amazon Web Service - SQS"]
 license = "Apache-2.0"


### PR DESCRIPTION
Fix the release version to be lower that 1.0.0 before the official release

We'll toggle the release to 1.0.0 when we publish to PyPi. I also removed the sections from release.yml for the time being to prevent the package from getting published to PyPI