### PR TITLE
bug: Uses the same AWS session for the S3 client as used by the SQS client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "amazon-sqs-extended-client"
-version = "1.0.0"
+version = "1.0.1"
 description = "Python version of AWS SQS extended client"
 authors = ["Amazon Web Service - SQS"]
 license = "Apache-2.0"

--- a/src/sqs_extended_client/client.py
+++ b/src/sqs_extended_client/client.py
@@ -653,7 +653,7 @@ class SQSExtendedClientSession(boto3.session.Session):
         class_attributes["get_from_receipt_handle_by_marker"] = _get_from_receipt_handle_by_marker
 
         # Adding the S3 client to the object
-        class_attributes["s3_client"] = boto3.client("s3")
+        class_attributes["s3_client"] = super().client("s3")
 
         # overwriting the send_message function
         class_attributes["send_message"] = _send_message_decorator(class_attributes["send_message"])


### PR DESCRIPTION
*Issue #, if available:* 18

*Description of changes:*

Now uses the same AWS session for the S3 client as used by the SQS client, rather than creating a new session with default credentials.   This allows users to use the non-default profile

fixes awslabs/amazon-sqs-python-extended-client-lib#18

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
