### PR TITLE
Fix logic used to calculate BinaryValue's lenght

### DIFF
--- a/src/sqs_extended_client/client.py
+++ b/src/sqs_extended_client/client.py
@@ -83,7 +83,14 @@ def _validate_required_parameters(self, required_params: list, error_message: st
         
     return
 
+def _get_bytes_size_in_bytes(self, b: bytes) -> int:
+    """
+    Responsible for calculating the size of a byte collection in bytes
 
+    :b: The byte collection whose size is to be determined.
+
+    """
+    return len(b)
 
 def _get_string_size_in_bytes(self, s: str) -> int:
     """
@@ -156,7 +163,7 @@ def _get_message_attributes_size(self, message_attributes: dict) -> int:
         
         binarytype_value = value.get("BinaryValue", 0)
         if binarytype_value:
-            total_message_attributes_size += self.get_string_size_in_bytes(binarytype_value)
+            total_message_attributes_size += self.get_bytes_size_in_bytes(binarytype_value)
         
     return total_message_attributes_size
 
@@ -636,6 +643,7 @@ class SQSExtendedClientSession(boto3.session.Session):
             _delete_delete_payload_from_s3
         )
 
+        class_attributes["get_bytes_size_in_bytes"] = _get_bytes_size_in_bytes
         class_attributes["get_string_size_in_bytes"] = _get_string_size_in_bytes
         class_attributes["get_reserved_attribute_name_if_present"] = _get_reserved_attribute_name_if_present
         class_attributes["get_s3_key"] = _get_s3_key


### PR DESCRIPTION
While trying to use this library with protobuf, we ran into an issue with the logic used to calculate the lenght of a Bytes type, BinaryValue. The function currently used accept a string and tries to encode it to UTF-8 before calculating the lenght.

```
def _get_string_size_in_bytes(self, s: str) -> int:
    """
    Responsible for calculating the size of a string in bytes

    :s: The string whose size is to be determined.

    """
    return len(s.encode('utf-8'))
```

I have created a new method specific for Bytes type that removes the encoding and it passes all the tests.

```
def _get_bytes_size_in_bytes(self, b: bytes) -> int:
    """
    Responsible for calculating the size of a byte collection in bytes

    :b: The byte collection whose size is to be determined.

    """
    return len(b)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
